### PR TITLE
Fix marriage proposal rates in vanilla games

### DIFF
--- a/Source/Rainbeau's Rational Romance/InteractionWorker_MarriageProposal_RandomSelectionWeight.cs
+++ b/Source/Rainbeau's Rational Romance/InteractionWorker_MarriageProposal_RandomSelectionWeight.cs
@@ -27,8 +27,8 @@ public static class InteractionWorker_MarriageProposal_RandomSelectionWeight
             return false;
         }
 
-        if (!SexualityUtilities.HasFreeSpouseCapacity(initiator) ||
-            !SexualityUtilities.HasFreeSpouseCapacity(recipient))
+        if (!SexualityUtilities.HasFreeSpouseFianceCapacity(initiator) ||
+            !SexualityUtilities.HasFreeSpouseFianceCapacity(recipient))
         {
             __result = 0f;
             return false;

--- a/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_BreakLoverAndFianceRelations.cs
+++ b/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_BreakLoverAndFianceRelations.cs
@@ -15,7 +15,7 @@ public static class InteractionWorker_RomanceAttempt_BreakLoverAndFianceRelation
         oldLoversAndFiances = new List<Pawn>();
         var polyPartners = new List<(Pawn, PawnRelationDef)>();
         var num = 100;
-        while (num > 0 && !SexualityUtilities.HasFreeSpouseCapacity(pawn))
+        while (num > 0 && !SexualityUtilities.HasFreeLoverCapacity(pawn))
         {
             var leastLikedLover = LovePartnerRelationUtility.ExistingLeastLikedPawnWithRelation(pawn,
                 r => r.def == PawnRelationDefOf.Lover && !r.otherPawn.Dead);

--- a/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_RandomSelectionWeight.cs
+++ b/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_RandomSelectionWeight.cs
@@ -67,7 +67,7 @@ public static class InteractionWorker_RomanceAttempt_RandomSelectionWeight
 
         var initiator_partner = LovePartnerRelationUtility.ExistingMostLikedLovePartner(initiator, false);
         if (initiator_partner != null && initiator.relations.OpinionOf(initiator_partner) >= 33 &&
-            !SexualityUtilities.HasFreeSpouseCapacity(initiator))
+            !SexualityUtilities.HasFreeLoverCapacity(initiator))
         {
             if (!initiator.story.traits.HasTrait(RRRTraitDefOf.Polyamorous) &&
                 !initiator.story.traits.HasTrait(RRRTraitDefOf.Philanderer))
@@ -79,7 +79,7 @@ public static class InteractionWorker_RomanceAttempt_RandomSelectionWeight
 
         var recipient_partner = LovePartnerRelationUtility.ExistingMostLikedLovePartner(recipient, false);
         if (recipient_partner != null && recipient.relations.OpinionOf(recipient_partner) >= 33 &&
-            !SexualityUtilities.HasFreeSpouseCapacity(recipient))
+            !SexualityUtilities.HasFreeLoverCapacity(recipient))
         {
             if (!recipient.story.traits.HasTrait(RRRTraitDefOf.Polyamorous) &&
                 !recipient.story.traits.HasTrait(RRRTraitDefOf.Philanderer))
@@ -91,7 +91,7 @@ public static class InteractionWorker_RomanceAttempt_RandomSelectionWeight
 
         var cheatChance = 1f;
         var pawn = LovePartnerRelationUtility.ExistingMostLikedLovePartner(initiator, false);
-        if (pawn != null && !SexualityUtilities.HasFreeSpouseCapacity(initiator))
+        if (pawn != null && !SexualityUtilities.HasFreeLoverCapacity(initiator))
         {
             float opinionOfPartner = initiator.relations.OpinionOf(pawn);
             if (initiator.story.traits.HasTrait(RRRTraitDefOf.Polyamorous))

--- a/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_SuccessChance.cs
+++ b/Source/Rainbeau's Rational Romance/InteractionWorker_RomanceAttempt_SuccessChance.cs
@@ -28,7 +28,7 @@ public static class InteractionWorker_RomanceAttempt_SuccessChance
             !SexualityUtilities.HasNonPolyPartner(recipient))
         {
         }
-        else if (!SexualityUtilities.HasFreeSpouseCapacity(recipient))
+        else if (!SexualityUtilities.HasFreeLoverCapacity(recipient))
         {
             var single1 = 1f;
             Pawn firstDirectRelationPawn = null;

--- a/Source/Rainbeau's Rational Romance/LovePartnerRelationUtility_ChangeSpouseRelationsToExSpouse.cs
+++ b/Source/Rainbeau's Rational Romance/LovePartnerRelationUtility_ChangeSpouseRelationsToExSpouse.cs
@@ -19,7 +19,7 @@ public static class LovePartnerRelationUtility_ChangeSpouseRelationsToExSpouse
         foreach (var spousePawn in spouses)
         {
             if (!spousePawn.Dead && (spousePawn.story.traits.HasTrait(RRRTraitDefOf.Polyamorous) ||
-                                     SexualityUtilities.HasFreeSpouseCapacity(pawn)))
+                                     SexualityUtilities.HasFreeLoverCapacity(pawn)))
             {
                 continue;
             }

--- a/Source/Rainbeau's Rational Romance/SexualityUtilities.cs
+++ b/Source/Rainbeau's Rational Romance/SexualityUtilities.cs
@@ -363,8 +363,13 @@ public static class SexualityUtilities
         return psylove != null && psylove.target == recipient;
     }
 
-    public static bool HasFreeSpouseCapacity(Pawn pawn)
+    public static bool HasFreeLoverCapacity(Pawn pawn)
     {
         return IdeoUtility.DoerWillingToDo(pawn.GetHistoryEventForLoveRelationCountPlusOne(), pawn);
+    }
+
+    public static bool HasFreeSpouseFianceCapacity(Pawn pawn)
+    {
+        return IdeoUtility.DoerWillingToDo(pawn.GetHistoryEventForSpouseAndFianceCountPlusOne(), pawn);
     }
 }


### PR DESCRIPTION
The base game uses different partner counting methods for romance vs. marriage proposals. The previous did not make this distinction causing marriage proposals chance to be zero in games using vanilla 1.3.